### PR TITLE
feat(switch-brand): add group brand support in switch brand modal

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,16 @@
+# [0.10.0-beta.1](https://github.com/counterfake/counterfake-dashboard/compare/v0.9.0...v0.10.0-beta.1) (2025-10-06)
+
+
+### Features
+
+* **switch-brand:** add group brand support in switch brand modal ([0b05151](https://github.com/counterfake/counterfake-dashboard/commit/0b05151a55e84417a130db180323f283c8bd9457))
+
+
+### BREAKING CHANGES
+
+* **switch-brand:** - switch brand modal now supports group brands. The brand list is fetched from the new endpoint which returns both individual and group brands. The UI has been updated to display group brands with a distinct icon.
+- The usage of some fields within user.brand has changed. user.brand.isGroupBrand and user.brand.id are now checked against the "brand_type" field returned by the server. Additionally, fields that request using user.brand.id now use user.brand.ownedBrand.
+
 # [0.9.0](https://github.com/counterfake/counterfake-dashboard/compare/v0.8.0...v0.9.0) (2025-10-03)
 
 

--- a/app/dashboard/(dashboard)/products/_hooks/use-products-page-data.ts
+++ b/app/dashboard/(dashboard)/products/_hooks/use-products-page-data.ts
@@ -25,15 +25,17 @@ interface UseProductsPageDataProps {
 export function useProductsPageData({ queries }: UseProductsPageDataProps) {
   const { user } = useAuthStore();
 
+  const brands = user.brand.ownedBrands.join(",");
+
   // --------------------------
   // Fetch data
   // --------------------------
 
   const { data: closedCount } = useQuery(
-    productQueries.closedCount({ brandId: user?.brand.id })
+    productQueries.closedCount({ brandId: brands })
   );
   const { data: riskyCount } = useQuery(
-    productQueries.riskyCount({ brandId: user?.brand.id })
+    productQueries.riskyCount({ brandId: brands })
   );
 
   // Fetch product data

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "counterfake-app",
-  "version": "0.9.0",
+  "version": "0.10.0-beta.1",
   "private": true,
   "scripts": {
     "dev": "next dev --turbopack",

--- a/src/common/api/bp-api/auth/schemas.ts
+++ b/src/common/api/bp-api/auth/schemas.ts
@@ -53,6 +53,7 @@ export const whoamiResponseSchema = z.object({
     selectedCompany: z.object({
       brand_name: z.string(),
       id: z.number(),
+      brand_type: z.enum(["brand", "group_brand"]),
     }),
     roles: z.array(z.custom<UserRole>()),
     companyName: z.string(),

--- a/src/common/types/auth.ts
+++ b/src/common/types/auth.ts
@@ -13,7 +13,7 @@ export const userSchema = z.object({
   role: z.array(z.any()),
   brand: z.object({
     name: z.string().nullable().optional(), // TODO: Remove nullable and optional
-    id: z.string().nullable().optional(), // TODO: Remove nullable and optional
+    id: z.number().nullable(),
     slug: z.string().nullable().optional(), // TODO: Remove nullable and optional
     isGroupBrand: z.boolean(),
     ownedBrands: z.array(z.number().optional()),

--- a/src/entities/brand-protection/brand/brand.lib.ts
+++ b/src/entities/brand-protection/brand/brand.lib.ts
@@ -1,5 +1,8 @@
-import { BrandsResponseDto } from "@/shared/api/brand-protection/bp-api.types";
-import { Brands } from "./brand.types";
+import {
+  BrandsResponseDto,
+  GroupBrandsResponseDto,
+} from "@/shared/api/brand-protection/bp-api.types";
+import { Brands, GroupBrand } from "./brand.types";
 
 export function transformBrandsDtoToBrands(
   brandsDto: BrandsResponseDto
@@ -17,4 +20,13 @@ export function transformBrandsDtoToBrands(
     totalPages: brandsDto.page_count,
     totalBrands: brandsDto.data_count,
   };
+}
+
+export function transformGroupBrandsDtoToBrands(
+  groupBrandsDto: GroupBrandsResponseDto
+): GroupBrand[] {
+  return groupBrandsDto?.results?.map((brand) => ({
+    id: brand.id,
+    name: brand.name,
+  }));
 }

--- a/src/entities/brand-protection/brand/brand.model.ts
+++ b/src/entities/brand-protection/brand/brand.model.ts
@@ -1,31 +1,64 @@
 import { queryOptions } from "@tanstack/react-query";
 
-import { getBrands } from "@/shared/api/brand-protection/bp-api.service";
+import {
+  getBrands,
+  getGroupBrands,
+} from "@/shared/api/brand-protection/bp-api.service";
 
 import { HttpClient } from "@/shared/api/http-client";
 
 import type { BrandsQueryParams } from "./brand.types";
-import { transformBrandsDtoToBrands } from "./brand.lib";
+import {
+  transformBrandsDtoToBrands,
+  transformGroupBrandsDtoToBrands,
+} from "./brand.lib";
 
 export const BRANDS_ROOT_QUERY_KEY = ["brand-protection", "brands"] as const;
 
-export const brandsQueryOptions = (params: BrandsQueryParams) => {
-  return queryOptions({
-    queryKey: [...BRANDS_ROOT_QUERY_KEY, params],
-    queryFn: async () => {
-      const response = await getBrands({
-        group: params.groupBrandId,
-        page_number: params.page,
-        page_size: params.limit,
-      });
+export const brandKeys = {
+  all: ["brand-protection", "brands"] as const,
+  lists: () => [...brandKeys.all, "lists"],
+  list: (params: BrandsQueryParams) => [...brandKeys.lists(), params],
+  groupLists: () => [...brandKeys.lists(), "groups"],
+  groupList: (params: BrandsQueryParams) => [...brandKeys.groupLists(), params],
+};
 
-      if (!response.success) {
-        return HttpClient.errorResult(response.error, "brandsQueryOptions");
-      }
+export const brandQueries = {
+  list: (params: BrandsQueryParams) =>
+    queryOptions({
+      queryKey: brandKeys.list(params),
+      queryFn: async () => {
+        const response = await getBrands({
+          group: params.groupBrandId,
+          page_number: params.page,
+          page_size: params.limit,
+        });
 
-      const brands = transformBrandsDtoToBrands(response.data);
+        if (!response.success) {
+          return HttpClient.errorResult(response.error, "brandsQueryOptions");
+        }
 
-      return HttpClient.successResult(brands);
-    },
-  });
+        const brands = transformBrandsDtoToBrands(response.data);
+
+        return HttpClient.successResult(brands);
+      },
+    }),
+  groupList: (params: BrandsQueryParams) =>
+    queryOptions({
+      queryKey: brandKeys.groupList(params),
+      queryFn: async () => {
+        const response = await getGroupBrands({
+          page_size: params.limit,
+          page_number: params.page,
+        });
+
+        if (!response.success) {
+          return HttpClient.errorResult(response.error, "brandsQueryOptions");
+        }
+
+        const brands = transformGroupBrandsDtoToBrands(response.data);
+
+        return HttpClient.successResult(brands);
+      },
+    }),
 };

--- a/src/entities/brand-protection/brand/brand.schemas.ts
+++ b/src/entities/brand-protection/brand/brand.schemas.ts
@@ -12,6 +12,11 @@ export const BrandSchema = z.object({
   groupBrandId: z.number(),
 });
 
+export const GroupBrandSchema = z.object({
+  id: z.number(),
+  name: z.string(),
+});
+
 export const BrandsSchema = z.object({
   brands: z.array(BrandSchema),
   page: z.number(),

--- a/src/entities/brand-protection/brand/brand.types.ts
+++ b/src/entities/brand-protection/brand/brand.types.ts
@@ -1,9 +1,16 @@
 import { z } from "zod";
 
-import { BrandSchema, BrandsQuerySchema, BrandsSchema } from "./brand.schemas";
+import {
+  BrandSchema,
+  BrandsQuerySchema,
+  BrandsSchema,
+  GroupBrandSchema,
+} from "./brand.schemas";
 
 export type BrandsQueryParams = z.infer<typeof BrandsQuerySchema>;
 
 export type Brand = z.infer<typeof BrandSchema>;
 
 export type Brands = z.infer<typeof BrandsSchema>;
+
+export type GroupBrand = z.infer<typeof GroupBrandSchema>;

--- a/src/features/authentication/services/customer.service.ts
+++ b/src/features/authentication/services/customer.service.ts
@@ -62,15 +62,11 @@ export class CustomerService {
     const brands = brandsResponse?.data?.results || [];
 
     const userBrandResult = this.getCustomerBrandResult({
-      userBrandName: currentCustomer?.selectedCompany?.brand_name,
+      userBrandType: currentCustomer?.selectedCompany?.brand_type,
       userBrandId: currentCustomer?.selectedCompany?.id,
       groupBrands,
       brands,
     });
-
-    if (!userBrandResult?.brandId || !userBrandResult?.brandSlug) {
-      // Todo: Handle this case
-    }
 
     const validatedCustomer = userSchema.safeParse({
       id: currentCustomer?.uid, // Give firebase uid as id
@@ -79,8 +75,7 @@ export class CustomerService {
       role: currentCustomer?.roles,
       brand: {
         name: currentCustomer?.selectedCompany?.brand_name,
-        id: userBrandResult.brandId || undefined, // TODO: Remove undefined
-        slug: userBrandResult.brandSlug || undefined, // TODO: Remove undefined
+        id: userBrandResult.brandId,
         isGroupBrand: userBrandResult.isGroupBrand,
         ownedBrands: userBrandResult.ownedBrands,
       },
@@ -96,26 +91,21 @@ export class CustomerService {
   }
 
   private getCustomerBrandResult(data: {
-    userBrandName?: string;
     userBrandId?: number;
+    userBrandType?: "brand" | "group_brand";
     groupBrands: GetGroupBrandsResponse["results"];
     brands: GetBrandsResponse["results"];
   }) {
-    const { userBrandName, userBrandId, groupBrands, brands } = data;
+    const { userBrandId, userBrandType, groupBrands, brands } = data;
 
-    /**
-     * check if the selected brand is a group brand
-     */
-    const groupBrand = groupBrands?.find(
-      (brand) =>
-        brand?.name?.toLocaleLowerCase() === userBrandName?.toLocaleLowerCase()
-    );
-
-    let currentBrandId: string | null = null;
-    let currentBrandSlug: string | null = null;
+    let brandId: number | null = null;
     let ownedBrands: number[] = [];
 
-    if (groupBrand) {
+    if (userBrandType === "group_brand") {
+      const groupBrand = groupBrands?.find(
+        (brand) => brand?.id === userBrandId
+      );
+
       /**
        * if the selected brand is a group brand, set the child brands
        * of the group brand as strings. In this way, it provides easy
@@ -127,26 +117,18 @@ export class CustomerService {
         // give the ids of child brands as an array
         .map((childBrand) => childBrand?.id);
 
-      currentBrandId = childBrandIds.join(",");
-      currentBrandSlug = groupBrand?.slug || null;
       ownedBrands = childBrandIds;
-    } else {
-      // if the selected brand is not a group brand, set the selected brand directly
-      const brand = brands?.find(
-        (item) =>
-          item?.brand_name?.toLocaleLowerCase() ===
-          userBrandName?.toLocaleLowerCase()
-      );
-      currentBrandId = brand ? String(userBrandId) : undefined; // TODO: Fix this handling
-      currentBrandSlug = brand?.brand_slug || null;
+      brandId = groupBrand?.id;
+    }
 
-      if (brand && "id" in brand) ownedBrands.push(brand.id);
+    if (userBrandType === "brand") {
+      ownedBrands.push(userBrandId);
+      brandId = userBrandId;
     }
 
     return {
-      isGroupBrand: !!groupBrand,
-      brandId: currentBrandId,
-      brandSlug: currentBrandSlug,
+      isGroupBrand: userBrandType === "group_brand",
+      brandId,
       ownedBrands,
     };
   }

--- a/src/features/customer/switch-brand/switch-brand.types.ts
+++ b/src/features/customer/switch-brand/switch-brand.types.ts
@@ -1,4 +1,5 @@
 export type Brand = {
   name: string;
   id: number;
+  isGroupBrand: boolean;
 };

--- a/src/features/customer/switch-brand/switch-brand.ui.tsx
+++ b/src/features/customer/switch-brand/switch-brand.ui.tsx
@@ -1,5 +1,5 @@
 import { useState, Suspense } from "react";
-import { Check, ChevronsUpDown, Loader2 } from "lucide-react";
+import { Check, ChevronsUpDown, Loader2, RefreshCw } from "lucide-react";
 
 import { cn } from "@/shared/lib/cn";
 
@@ -18,10 +18,18 @@ import {
   CommandItem,
   CommandList,
 } from "@/shared/ui/primitives/command";
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogHeader,
+  DialogTitle,
+  DialogTrigger,
+} from "@/common/components/ui/primitives/dialog";
 
 import {
   useSwitchBrand,
-  useSuspenseBrandsQuery,
+  useSuspenseAllBrands,
   useCurrentBrand,
 } from "./switch-brand.model";
 
@@ -43,84 +51,240 @@ export function SwitchBrand() {
 
 function SwitchBrandBase() {
   const switchBrand = useSwitchBrand();
-  const brands = useSuspenseBrandsQuery();
+  const { brands, groupBrands } = useSuspenseAllBrands();
   const currentBrand = useCurrentBrand();
   const toast = useToast();
 
-  const [selectedBrand, setSelectedBrand] = useState<number>(currentBrand.id);
+  const [selectedBrandId, setSelectedBrandId] = useState<number | null>(null);
+  const [selectedGroupBrandId, setSelectedGroupBrandId] = useState<
+    number | null
+  >(null);
+  const [openBrandPopover, setOpenBrandPopover] = useState(false);
+  const [openGroupBrandPopover, setOpenGroupBrandPopover] = useState(false);
+  const [openDialog, setOpenDialog] = useState(false);
 
-  const handleSwitchBrand = async () => {
-    const brand = brands.find((brand) => brand.id === selectedBrand);
+  const handleSelectBrand = (brandId: number) => {
+    setSelectedBrandId(brandId);
+    setOpenBrandPopover(false);
+  };
 
+  const handleSelectGroupBrand = (groupBrandId: number) => {
+    setSelectedGroupBrandId(groupBrandId);
+    setOpenGroupBrandPopover(false);
+  };
+
+  const handleSwitchToGroupBrand = async () => {
+    if (!selectedGroupBrandId) return;
+
+    const groupBrand = groupBrands.find((gb) => gb.id === selectedGroupBrandId);
     await switchBrand.mutateAsync({
-      brandName: brand?.name,
-      brandId: brand?.id,
+      brandName: groupBrand?.name || "",
+      brandId: groupBrand?.id || 0,
+      isGroupBrand: true,
     });
 
     toast.info(
       "Brand switched successfully",
       "All data will be reloaded. Please wait..."
     );
+
+    setSelectedGroupBrandId(null);
+    setOpenDialog(false);
   };
 
-  const isDifferentSelect = selectedBrand !== currentBrand.id;
+  const handleSwitchToBrand = async () => {
+    if (!selectedBrandId) return;
+
+    const brand = brands.find((b) => b.id === selectedBrandId);
+    await switchBrand.mutateAsync({
+      brandName: brand?.name || "",
+      brandId: brand?.id || 0,
+      isGroupBrand: false,
+    });
+
+    toast.info(
+      "Brand switched successfully",
+      "All data will be reloaded. Please wait..."
+    );
+
+    setSelectedBrandId(null);
+    setOpenDialog(false);
+  };
 
   return (
     <div className="space-y-2">
-      <Popover>
-        <PopoverTrigger asChild>
-          <Button
-            variant="outline"
-            role="combobox"
-            className="w-full justify-between"
-            size="sm"
-          >
-            {selectedBrand
-              ? brands.find((brand) => brand.id === selectedBrand)?.name
-              : "Select brand..."}
-            <ChevronsUpDown className="w-3 h-3 opacity-50" />
-          </Button>
-        </PopoverTrigger>
-        <PopoverContent className="w-[200px] p-0">
-          <Command>
-            <CommandInput placeholder="Search brand..." className="h-9" />
-            <CommandList>
-              <CommandEmpty>No brand found.</CommandEmpty>
-              <CommandGroup>
-                {brands.map((brand) => (
-                  <CommandItem
-                    key={brand.name}
-                    value={brand.name}
-                    onSelect={() => {
-                      setSelectedBrand(brand.id);
-                    }}
-                  >
-                    {brand.name}
-                    <Check
-                      className={cn(
-                        "ml-auto",
-                        selectedBrand === brand.id ? "opacity-100" : "opacity-0"
-                      )}
-                    />
-                  </CommandItem>
-                ))}
-              </CommandGroup>
-            </CommandList>
-          </Command>
-        </PopoverContent>
-      </Popover>
+      {/* Mevcut Seçili Brand */}
+      <div className="p-2 bg-muted rounded-md">
+        <p className="text-xs text-muted-foreground mb-1">Current Brand</p>
+        <div className="flex items-center justify-between">
+          <p className="text-sm font-medium">{currentBrand.name}</p>
+          <span className="text-xs px-2 py-0.5 rounded-full bg-primary/10 text-primary">
+            {currentBrand.isGroupBrand ? "Group Brand" : "Brand"}
+          </span>
+        </div>
+      </div>
 
-      <Button
-        size="sm"
-        className="w-full"
-        onClick={handleSwitchBrand}
-        disabled={switchBrand.isPending || !isDifferentSelect}
-      >
-        {switchBrand.isPending && (
-          <Loader2 className="mr-2 h-4 w-4 animate-spin" />
-        )}
-        Change Brand
-      </Button>
+      {/* Switch Brand Dialog */}
+      <Dialog open={openDialog} onOpenChange={setOpenDialog}>
+        <DialogTrigger asChild>
+          <Button variant="outline" size="sm" className="w-full">
+            <RefreshCw className="w-3 h-3 mr-2" />
+            Switch Brand
+          </Button>
+        </DialogTrigger>
+        <DialogContent className="sm:max-w-md">
+          <DialogHeader>
+            <DialogTitle>Switch Brand</DialogTitle>
+            <DialogDescription>
+              Choose a group brand or a regular brand to switch to.
+            </DialogDescription>
+          </DialogHeader>
+
+          <div className="space-y-4 py-4">
+            {/* Group Brands Select */}
+            <div className="space-y-2">
+              <label className="text-sm font-medium">Group Brand</label>
+              <Popover
+                open={openGroupBrandPopover}
+                onOpenChange={setOpenGroupBrandPopover}
+              >
+                <PopoverTrigger asChild>
+                  <Button
+                    variant="outline"
+                    role="combobox"
+                    className="w-full justify-between"
+                    size="sm"
+                  >
+                    {selectedGroupBrandId
+                      ? groupBrands.find((gb) => gb.id === selectedGroupBrandId)
+                          ?.name
+                      : "Select group brand..."}
+                    <ChevronsUpDown className="w-3 h-3 opacity-50" />
+                  </Button>
+                </PopoverTrigger>
+                <PopoverContent className="w-full p-0">
+                  <Command>
+                    <CommandInput
+                      placeholder="Search group brand..."
+                      className="h-9"
+                    />
+                    <CommandList className="max-h-[200px]">
+                      <CommandEmpty>No group brand found.</CommandEmpty>
+                      <CommandGroup>
+                        {groupBrands.map((groupBrand) => (
+                          <CommandItem
+                            key={groupBrand.id}
+                            value={groupBrand.name}
+                            onSelect={() =>
+                              handleSelectGroupBrand(groupBrand.id)
+                            }
+                          >
+                            {groupBrand.name}
+                            <Check
+                              className={cn(
+                                "ml-auto",
+                                selectedGroupBrandId === groupBrand.id
+                                  ? "opacity-100"
+                                  : "opacity-0"
+                              )}
+                            />
+                          </CommandItem>
+                        ))}
+                      </CommandGroup>
+                    </CommandList>
+                  </Command>
+                </PopoverContent>
+              </Popover>
+              <Button
+                size="sm"
+                className="w-full"
+                onClick={handleSwitchToGroupBrand}
+                disabled={switchBrand.isPending || !selectedGroupBrandId}
+              >
+                {switchBrand.isPending && (
+                  <Loader2 className="mr-2 h-4 w-4 animate-spin" />
+                )}
+                Change to Group Brand
+              </Button>
+            </div>
+
+            <div className="relative">
+              <div className="absolute inset-0 flex items-center">
+                <span className="w-full border-t" />
+              </div>
+              <div className="relative flex justify-center text-xs uppercase">
+                <span className="bg-background px-2 text-muted-foreground">
+                  Or
+                </span>
+              </div>
+            </div>
+
+            {/* Normal Brands Select */}
+            <div className="space-y-2">
+              <label className="text-sm font-medium">Brand</label>
+              <Popover
+                open={openBrandPopover}
+                onOpenChange={setOpenBrandPopover}
+              >
+                <PopoverTrigger asChild>
+                  <Button
+                    variant="outline"
+                    role="combobox"
+                    className="w-full justify-between"
+                    size="sm"
+                  >
+                    {selectedBrandId
+                      ? brands.find((b) => b.id === selectedBrandId)?.name
+                      : "Select brand..."}
+                    <ChevronsUpDown className="w-3 h-3 opacity-50" />
+                  </Button>
+                </PopoverTrigger>
+                <PopoverContent className="w-full p-0">
+                  <Command>
+                    <CommandInput
+                      placeholder="Search brand..."
+                      className="h-9"
+                    />
+                    <CommandList className="max-h-[200px]">
+                      <CommandEmpty>No brand found.</CommandEmpty>
+                      <CommandGroup>
+                        {brands.map((brand) => (
+                          <CommandItem
+                            key={brand.id}
+                            value={brand.name}
+                            onSelect={() => handleSelectBrand(brand.id)}
+                          >
+                            {brand.name}
+                            <Check
+                              className={cn(
+                                "ml-auto",
+                                selectedBrandId === brand.id
+                                  ? "opacity-100"
+                                  : "opacity-0"
+                              )}
+                            />
+                          </CommandItem>
+                        ))}
+                      </CommandGroup>
+                    </CommandList>
+                  </Command>
+                </PopoverContent>
+              </Popover>
+              <Button
+                size="sm"
+                className="w-full"
+                onClick={handleSwitchToBrand}
+                disabled={switchBrand.isPending || !selectedBrandId}
+              >
+                {switchBrand.isPending && (
+                  <Loader2 className="mr-2 h-4 w-4 animate-spin" />
+                )}
+                Change to Brand
+              </Button>
+            </div>
+          </div>
+        </DialogContent>
+      </Dialog>
     </div>
   );
 }

--- a/src/features/products/hooks/use-customer-products.ts
+++ b/src/features/products/hooks/use-customer-products.ts
@@ -24,14 +24,14 @@ export function useGetCustomerProductResults(
   const { user } = useAuthStore();
 
   const paramsWithBrand = {
-    brand: user?.brand?.id,
+    brand: user?.brand?.ownedBrands.join(","),
     ...params,
   };
 
   return useApiQuery({
     queryKey: [CUSTOMER_PRODUCTS_NAMESPACE, "results", paramsWithBrand],
     queryFn: () => productService.getProductResults(paramsWithBrand),
-    enabled: !!user?.brand?.id,
+    enabled: !!paramsWithBrand.brand,
     emptyData: {
       limit: 0,
       page: 0,
@@ -43,12 +43,14 @@ export function useGetCustomerProductResults(
 }
 
 export function useGetCustomerProductById(productId: string) {
-  const { user } = useAuthStore();
+  const {
+    user: { brand },
+  } = useAuthStore();
 
   return useApiQuery({
     queryKey: [CUSTOMER_PRODUCTS_NAMESPACE, productId],
     queryFn: () => productService.getProductById(productId),
-    enabled: !!user?.brand?.id || !!productId,
+    enabled: !!brand?.ownedBrands.length && !!productId,
     emptyData: productEmptyData,
   });
 }
@@ -59,7 +61,7 @@ export function useGetCustomerProductCategories(
   const { user } = useAuthStore();
 
   const paramsWithBrand = {
-    brand: user?.brand?.id,
+    brand: user?.brand?.ownedBrands.join(","),
     ...params,
   };
 
@@ -67,7 +69,7 @@ export function useGetCustomerProductCategories(
     queryKey: [CUSTOMER_PRODUCTS_NAMESPACE, "categories", paramsWithBrand],
     queryFn: () =>
       productCategoriesService.getProductCategories(paramsWithBrand),
-    enabled: !!user?.brand?.id,
+    enabled: !!paramsWithBrand.brand,
     emptyData: [],
   });
 }
@@ -81,14 +83,14 @@ export function useGetCustomerProductAnalysis(
   const { user } = useAuthStore();
 
   const paramsWithBrand = {
-    brand: user?.brand?.id,
+    brand: user?.brand?.ownedBrands.join(","),
     ...params,
   };
 
   return useApiQuery({
     queryKey: [CUSTOMER_PRODUCTS_NAMESPACE, "analysis", paramsWithBrand],
     queryFn: () => productAnalysisService.getProductAnalysis(paramsWithBrand),
-    enabled: !!user?.brand?.id,
+    enabled: !!paramsWithBrand.brand,
     emptyData: {
       platforms: [],
       sellers: [],
@@ -103,7 +105,7 @@ export function useGetCustomerProductAnalysisMonthly(
   const { user } = useAuthStore();
 
   const paramsWithBrand = {
-    brand: user?.brand?.id,
+    brand: user?.brand?.ownedBrands.join(","),
     ...params,
   };
 
@@ -115,7 +117,7 @@ export function useGetCustomerProductAnalysisMonthly(
     ],
     queryFn: () =>
       productAnalysisService.getProductAnalysisMonthly(paramsWithBrand),
-    enabled: !!user?.brand?.id,
+    enabled: !!paramsWithBrand.brand,
     emptyData: [],
   });
 }

--- a/src/features/seller-profile/hooks/use-customer-seller-profiles.ts
+++ b/src/features/seller-profile/hooks/use-customer-seller-profiles.ts
@@ -8,14 +8,16 @@ const NAMESPACE = "seller-profile";
 export function useGetSellerProfileById(id: number) {
   const { user } = useAuthStore();
 
+  const brands = user?.brand?.ownedBrands.join(",");
+
   return useApiQuery({
-    queryKey: [NAMESPACE, id, user?.brand?.id],
+    queryKey: [NAMESPACE, id, brands],
     queryFn: () => {
       return sellerProfileService.getSellerProfileById(id, {
-        brand: user?.brand?.id || "",
+        brand: brands || "",
       });
     },
-    enabled: !!user?.brand?.id && !!id,
+    enabled: !!brands && !!id,
     emptyData: {
       address: "",
       category: null,
@@ -40,14 +42,16 @@ export function useGetSellerProfileById(id: number) {
 export function useGetCustomerSellersTopFakes() {
   const { user } = useAuthStore();
 
+  const brands = user?.brand?.ownedBrands.join(",");
+
   return useApiQuery({
-    queryKey: [NAMESPACE, "sellers-top-fakes", user?.brand?.id],
+    queryKey: [NAMESPACE, "sellers-top-fakes", brands],
     queryFn: () => {
       return sellerProfileService.getSellersTopFakes({
-        brand: user?.brand?.id || "",
+        brand: brands || "",
       });
     },
-    enabled: !!user?.brand?.id,
+    enabled: !!brands,
     emptyData: [],
   });
 }

--- a/src/pages/seller-profile-detail/model/hooks/use-seller-profile-data.ts
+++ b/src/pages/seller-profile-detail/model/hooks/use-seller-profile-data.ts
@@ -6,9 +6,11 @@ import { sellerProfileQueries } from "@/entities/brand-protection/seller-profile
 export function useSuspenseSellerProfileData(id: number) {
   const { user } = useAuthStore();
 
+  const brands = user?.brand?.ownedBrands.join(",");
+
   const { data: profile } = useSuspenseQuery(
     sellerProfileQueries.detail(id, {
-      brandId: user?.brand?.id,
+      brandId: brands || "",
     })
   );
 

--- a/src/pages/seller-profile-detail/ui/seller-item.tsx
+++ b/src/pages/seller-profile-detail/ui/seller-item.tsx
@@ -38,6 +38,8 @@ export function SellerItem({ seller, showSeparator }: SellerItemProps) {
   const [currentPage, setCurrentPage] = useState(1);
   const { user } = useAuthStore();
 
+  const brands = user?.brand?.ownedBrands.join(",");
+
   const ITEMS_PER_PAGE = 10;
 
   // Only fetch products when expanded
@@ -45,10 +47,10 @@ export function SellerItem({ seller, showSeparator }: SellerItemProps) {
     ...productQueries.list({
       page: currentPage,
       limit: ITEMS_PER_PAGE,
-      brandId: user?.brand?.id,
+      brandId: brands || "",
       sellerId: seller.id,
     }),
-    enabled: isExpanded && !!user?.brand?.id,
+    enabled: isExpanded && !!brands,
   });
 
   const products = productsData?.products || [];

--- a/src/shared/api/brand-protection/bp-api.schemas.ts
+++ b/src/shared/api/brand-protection/bp-api.schemas.ts
@@ -23,6 +23,7 @@ export const RefreshTokenResponseDtoSchema = z.object({
 export const UpdateSelectedCompanyRequestDtoSchema = z.object({
   id: z.number(),
   brand_name: z.string(),
+  brand_type: z.enum(["brand", "group_brand"]),
 });
 
 // --------------------------
@@ -62,9 +63,15 @@ export const BrandsResponseDtoSchema = z.object({
 // --------------------------
 export const GroupBrandsQueryDtoSchema = z.object({
   page_size: z.number().optional(),
+  page_number: z.number().optional(),
 });
 
 export const GroupBrandsResponseDtoSchema = z.object({
+  data_count: z.number(),
+  generated_at: z.string(),
+  page_count: z.number(),
+  page_number: z.number(),
+  page_size: z.number(),
   results: z.array(
     z.object({
       id: z.number(),

--- a/src/widgets/seller-profile-card/model/hooks/use-seller-profile-data.ts
+++ b/src/widgets/seller-profile-card/model/hooks/use-seller-profile-data.ts
@@ -10,13 +10,15 @@ import {
 export function useSellerProfileData(sellerId: number) {
   const { user } = useAuthStore();
 
+  const brands = user?.brand?.ownedBrands.join(",");
+
   const {
     data: profile,
     isLoading,
     error,
   } = useQuery({
     ...sellerProfileQueries.detail(sellerId, {
-      brandId: user?.brand?.id,
+      brandId: brands || "",
     }),
   });
 


### PR DESCRIPTION
BREAKING CHANGE:
- switch brand modal now supports group brands. The brand list is fetched from the new endpoint which returns both individual and group brands. The UI has been updated to display group brands with a distinct icon.
- The usage of some fields within user.brand has changed. user.brand.isGroupBrand and user.brand.id are now checked against the "brand_type" field returned by the server. Additionally, fields that request using user.brand.id now use user.brand.ownedBrand.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Yeni Özellikler
  - Marka değiştirme modali artık grup markalarını da destekliyor; mevcut marka gösterimi, ayrı listeler ve arama ile grup/tekil marka seçimi yapılabilir. Grup markaları ayırt edilebilir simgeyle görüntülenir.
- İyileştirmeler
  - Ürünler ve satıcı profilleri, birden fazla sahip olunan markayı kapsayacak şekilde filtrelenir; ilgili sayımlarda ve detaylarda daha kapsamlı sonuçlar.
- Dokümantasyon
  - Ön sürüm için değişiklik günlüğü güncellendi; yeni özellikler ve uyumluluk notları eklendi.
- Bakım
  - Sürüm 0.10.0-beta.1’e yükseltildi.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->